### PR TITLE
perf(ed25519): switch to chloride

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "asn1.js": "^4.9.0",
-    "tweetnacl": "^0.14.1"
+    "chloride": "^2.2.2"
   },
   "devDependencies": {
     "babel-loader": "^6.2.7",
@@ -90,8 +90,5 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
-  },
-  "optionalDependencies": {
-    "ed25519": "0.0.4"
   }
 }


### PR DESCRIPTION
Previously we were using ed25519 and tweetnacl NPM modules and manually attempted to detect the correct module to use. This caused issues with webpack. By using chloride, the switching is automatically done for us and chloride is smart enough to try to depend on prebuilt binaries if possible.
