### PR TITLE
Incorrect prefix in test stute / 0012_test-basic-threshold-schroedinger.json

### DIFF
--- a/testsuite/valid/0012_test-basic-threshold-schroedinger.json
+++ b/testsuite/valid/0012_test-basic-threshold-schroedinger.json
@@ -5,11 +5,11 @@
     "subfulfillments": [
       {
         "type": "preimage-sha-256",
-        "preimage": "YWFh"
+        "preimage": "aaa"
       },
       {
         "type": "preimage-sha-256",
-        "preimage": "YWFh"
+        "preimage": "aaa"
       }
     ]
   },


### PR DESCRIPTION
I could be wrong, but in order to get this test working with my code I had to change the prefix. This PR contains the fix.