### PR TITLE
fix: remove leftovers from previous implementation for draft 01

### DIFF
--- a/src/lib/condition.js
+++ b/src/lib/condition.js
@@ -344,24 +344,6 @@ class Condition {
   }
 
   /**
-   * Parse any condition in binary format.
-   *
-   * Will populate the condition object with data from the provided binary
-   * stream.
-   *
-   * @param {Reader} reader Binary stream containing the condition.
-   *
-   * @private
-   */
-  parseBinary (reader) {
-    this.setTypeId(reader.readUInt16())
-    this.setSubtypes(reader.readVarUInt())
-    // TODO Ensure subtypes is supported?
-    this.setHash(reader.readVarOctetString())
-    this.setCost(reader.readVarUInt())
-  }
-
-  /**
    * Ensure the condition is valid according the local rules.
    *
    * Checks the condition against the local subtypes (supported condition types)

--- a/src/lib/fulfillment.js
+++ b/src/lib/fulfillment.js
@@ -9,12 +9,6 @@ const Condition = require('./condition')
 const base64url = require('../util/base64url')
 const Asn1Fulfillment = require('../schemas/fulfillment').Fulfillment
 
-// Regex for validating fulfillments
-//
-// This is a generic, future-proof version of the fulfillment regular
-// expression.
-const FULFILLMENT_REGEX = /^cf:([1-9a-f][0-9a-f]{0,3}|0):[a-zA-Z0-9_-]*$/
-
 /**
  * Base class for fulfillment types.
  */
@@ -221,7 +215,5 @@ class Fulfillment {
     throw new Error('Not implemented')
   }
 }
-
-Fulfillment.REGEX = FULFILLMENT_REGEX
 
 module.exports = Fulfillment


### PR DESCRIPTION
This PR removes:

* no longer needed fulfillment regular expression
* no longer needed `Condition.parseBinary` -- it used to be that `Condition.fromBinary` would call `.parseBinary` but that is no longer the case as the parsing is done via `Condition.fromAsn1Json`
