### PR TITLE
Removed ES6 spread operator

### DIFF
--- a/src/types/prefix-sha256.js
+++ b/src/types/prefix-sha256.js
@@ -124,7 +124,7 @@ class PrefixSha256 extends BaseSha256 {
    * @return {Set<String>} Complete type names for this fulfillment.
    */
   getSubtypes () {
-    const subtypes = new Set([...this.subcondition.getSubtypes(), this.subcondition.getTypeName()])
+    const subtypes = new Set((this.subcondition.getSubtypes() || []).slice().push(this.subcondition.getTypeName()));
 
     // Never include our own type as a subtype. The reason is that we already
     // know that the validating implementation knows how to interpret this type,


### PR DESCRIPTION
We have problems using bigchaindb-driver package in Meteor.js because ES6 spread operator is used in this package.

Please see https://github.com/bigchaindb/js-bigchaindb-driver/issues/92